### PR TITLE
Add dependencies for click, writio, and pandas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ cldf-ldd = "^0.0.6"
 clldutils = "^3.20.0"
 cldfbench = "^1.14.0"
 morphinder = "^0.0.2"
+click ="*"
+writio ="*"
+pandas ="*"
 
 [tool.poetry.group.dev.dependencies]
 keepachangelog = "^1.0.0"


### PR DESCRIPTION
Fix this issue: https://github.com/fmatter/cldflex/issues/5

Was unable to do extensive dependency version testing, hence the version wildcard. Pls update if you have more knowledge of versions requirements.